### PR TITLE
Fix (no)ACK bit for compatiblity with ESB

### DIFF
--- a/src/esb.c
+++ b/src/esb.c
@@ -288,8 +288,8 @@ bool esb_send_packet(struct esbPacket_s *packet, struct esbPacket_s * ack, uint8
 
         return false;
     } else {
-        // Handling packet PID
-        packet->s1 = (pid<<1);
+        // Handling packet PID. S1 format is | PID(2) | ACK flag |
+        packet->s1 = ((pid & 0x03)<<1) | 1;
         pid++;
 
         bool ack_received = false;


### PR DESCRIPTION
Full ESB PRX implementations like the nRF24's and Nordic's ESB implementation
reads a "ACK" bit in the packet to know if an ack needs to be sent or not.

This ACK bit needs to be set to 1 in order for the PRX device to send an ack (assuming dynamic ack is enabled).

This PR hardcode the ACK bit to 1 in the S1 field of the packet to work with such implementations.