### PR TITLE
Add radio test USB controls

### DIFF
--- a/docs/development/compatible-usb-protocol.md
+++ b/docs/development/compatible-usb-protocol.md
@@ -95,6 +95,10 @@ Crazyradio vendor requests summary:
 |  0x40           | SET\_SNIFFER\_ADDRESS (0x25)           | Pipe (0-1) | Zero    | 5        | Address|
 |  0xC0           | GET\_SNIFFER\_DROP\_COUNT (0x26)       | Zero       | Zero    | 4        | uint32\_t LE|
 |  0x40           | SET\_PACKET\_LOSS\_SIMULATION (0x30)   | Zero       | Zero    | 2        | [packet_loss_percent: u8, ack_loss_percent:u8]
+|  0x40           | SET\_TEST\_MODE (0x31)                  | Mode (0-3) | Zero    | Zero     | None |
+|  0x40           | SET\_TEST\_NRF\_TX\_POWER (0x32)        | Raw TXPOWER| Zero    | Zero     | None |
+|  0x40           | SET\_TEST\_PA\_POWER (0x33)             | PA power   | Zero    | Zero     | None |
+|  0xC0           | GET\_TEST\_STATE (0x34)                 | Zero       | Zero    | 4        | [mode, channel, nRF TXPOWER, PA power] |
 |  0x40           | LAUNCH\_BOOTLOADER (0xFF)     | Zero       | Zero    | Zero     | None|
 
 ### Set radio channel
@@ -469,6 +473,72 @@ This means that the receiver will receive the packet, send the ack
 but the ack packet might be dropped by Crazyradio and reported as lost.
 
 Both case will look the same on the PC side: the packet is reported as not acked.
+
+---
+
+### Radio TEST controls
+
+The TEST requests are intended for radio test and measurement workflows.
+They do not replace the legacy Crazyradio PA-compatible requests used for
+normal Crazyflie communication, but power settings are applied to the firmware
+radio state and affect subsequent normal use until changed again.
+
+SET\_RADIO\_CHANNEL (0x01) is reused for TEST channel control. When a TEST
+carrier is active, changing the channel immediately retunes and restarts the
+active TEST carrier.
+
+**SET\_TEST\_MODE:**
+
+|  bmRequestType  | bRequest                    | wValue     | wIndex  | wLength  | data  |
+|  ---------------| ----------------------------| -----------| --------| ---------| ------|
+|  0x40           | SET\_TEST\_MODE (0x31)      | Mode (0-3) | Zero    | Zero     | None  |
+
+|  Mode  | Meaning                                           |
+|  ------| --------------------------------------------------|
+|  0     | Idle                                              |
+|  1     | Continuous unmodulated carrier                    |
+|  2     | Continuous modulated carrier, Nordic 1 Mbps       |
+|  3     | Continuous modulated carrier, Nordic 2 Mbps       |
+
+Invalid modes stall the USB setup request.
+
+**SET\_TEST\_NRF\_TX\_POWER:**
+
+|  bmRequestType  | bRequest                             | wValue      | wIndex  | wLength  | data  |
+|  ---------------| -------------------------------------| ------------| --------| ---------| ------|
+|  0x40           | SET\_TEST\_NRF\_TX\_POWER (0x32)    | Raw TXPOWER | Zero    | Zero     | None  |
+
+The wValue is the raw nRF52840 RADIO.TXPOWER register value. Accepted
+values include 0xD8, 0xEC, 0xF0, 0xF4, 0xF8, 0xFC, 0x00, and 0x02 through
+0x08 when supported. Invalid values stall the USB setup request. This setting
+also affects normal packet transmission until changed again.
+
+**SET\_TEST\_PA\_POWER:**
+
+|  bmRequestType  | bRequest                         | wValue   | wIndex  | wLength  | data  |
+|  ---------------| ---------------------------------| ---------| --------| ---------| ------|
+|  0x40           | SET\_TEST\_PA\_POWER (0x33)     | PA power | Zero    | Zero     | None  |
+
+The wValue is the nRF21540 TX gain and must be in the range 0..31. Invalid
+values stall the USB setup request. This setting also affects normal packet
+transmission until changed again.
+
+**GET\_TEST\_STATE:**
+
+|  bmRequestType  | bRequest                    | wValue  | wIndex  | wLength  | data                                  |
+|  ---------------| ----------------------------| --------| --------| ---------| --------------------------------------|
+|  0xC0           | GET\_TEST\_STATE (0x34)     | Zero    | Zero    | 4        | [mode, channel, nRF TXPOWER, PA power] |
+
+|  Offset  | Description                                             |
+|  --------| --------------------------------------------------------|
+|  0       | Current TEST mode                                       |
+|  1       | Current firmware-applied radio channel                  |
+|  2       | Current firmware-applied raw nRF52840 TXPOWER           |
+|  3       | Current firmware-applied nRF21540 PA gain               |
+
+Returned values are the firmware-applied hardware state, not GUI defaults.
+If startup firmware settings change later, GET\_TEST\_STATE reports those
+changed startup settings.
 
 ---
 

--- a/src/esb.c
+++ b/src/esb.c
@@ -27,6 +27,8 @@
 
 #include <zephyr/kernel.h>
 
+#include <string.h>
+
 #include <hal/nrf_radio.h>
 #include <nrfx_ppi.h>
 #include <nrfx_timer.h>
@@ -43,6 +45,18 @@ LOG_MODULE_REGISTER(esb);
 static K_MUTEX_DEFINE(radio_busy);
 static K_SEM_DEFINE(radioXferDone, 0, 1);
 
+#define ESB_DEFAULT_CHANNEL 42
+#define ESB_DEFAULT_NRF_TX_POWER ((uint8_t)NRF_RADIO_TXPOWER_0DBM)
+
+static esbTestMode_t test_mode = esbTestModeIdle;
+static uint8_t test_tx_packet[64];
+static uint8_t current_channel = ESB_DEFAULT_CHANNEL;
+static uint8_t current_nrf_tx_power = ESB_DEFAULT_NRF_TX_POWER;
+static nrf_radio_mode_t current_normal_radio_mode = NRF_RADIO_MODE_NRF_2MBIT;
+static uint8_t test_pa_power;
+
+static bool test_mode_is_modulated(void) { return test_mode == esbTestModeModulatedCarrier1M || test_mode == esbTestModeModulatedCarrier2M; }
+
 static bool isInit = false;
 static bool sending;
 static bool timeout;
@@ -53,12 +67,14 @@ static int arc = 3;
 static int packet_loss_percent = 0;
 static int ack_loss_percent = 0;
 
-static bool continuous_carrier_enabled = false;
-
 static bool sniffer_active = false;
 static esb_sniffer_rx_cb_t sniffer_callback = NULL;
 static struct esbPacket_s sniffer_rx_buffer;
 static uint8_t current_pipe0_address[5] = {0xe7, 0xe7, 0xe7, 0xe7, 0xe7};
+
+static void test_mode_stop_locked(void);
+static void test_mode_start_locked(void);
+static void test_mode_restart_locked(void);
 
 const nrfx_timer_t timer0 = NRFX_TIMER_INSTANCE(0);
 
@@ -66,6 +82,11 @@ static void radio_isr(void *arg)
 {
     nrf_radio_event_clear(NRF_RADIO, NRF_RADIO_EVENT_DISABLED);
     nrf_radio_event_clear(NRF_RADIO, NRF_RADIO_EVENT_END);
+
+    if (test_mode_is_modulated()) {
+        nrf_radio_task_trigger(NRF_RADIO, NRF_RADIO_TASK_START);
+        return;
+    }
 
     if (sniffer_active) {
         bool crc_ok = nrf_radio_crc_status_check(NRF_RADIO);
@@ -168,7 +189,7 @@ void esb_init()
 
     nrf_radio_power_set(NRF_RADIO, true);
 
-    nrf_radio_txpower_set(NRF_RADIO, NRF_RADIO_TXPOWER_0DBM);
+    nrf_radio_txpower_set(NRF_RADIO, (nrf_radio_txpower_t)ESB_DEFAULT_NRF_TX_POWER);
 
     // Low level packet configuration
     nrf_radio_packet_conf_t radioConfig = {0,};
@@ -183,8 +204,9 @@ void esb_init()
     nrf_radio_packet_configure(NRF_RADIO, &radioConfig);
 
     // Configure channel and bitrate
-    nrf_radio_mode_set(NRF_RADIO, NRF_RADIO_MODE_NRF_2MBIT);
-    nrf_radio_frequency_set(NRF_RADIO, 2442); // Channel 42
+    current_normal_radio_mode = NRF_RADIO_MODE_NRF_2MBIT;
+    nrf_radio_mode_set(NRF_RADIO, current_normal_radio_mode);
+    nrf_radio_frequency_set(NRF_RADIO, 2400 + ESB_DEFAULT_CHANNEL);
 
     // Configure Addresses
     nrf_radio_base0_set(NRF_RADIO, 0xe7e7e7e7);
@@ -204,6 +226,11 @@ void esb_init()
     irq_enable(RADIO_IRQn);
 
     fem_init();
+
+    current_channel = ESB_DEFAULT_CHANNEL;
+    current_nrf_tx_power = (uint8_t)nrf_radio_txpower_get(NRF_RADIO);
+    test_pa_power = fem_get_power();
+    test_mode = esbTestModeIdle;
 
     ack_enabled = true;
     arc = 3;
@@ -225,6 +252,9 @@ void esb_deinit()
     nrf_radio_power_set(NRF_RADIO, false);
     irq_disable(RADIO_IRQn);
 
+    fem_txen_set(false);
+    test_mode = esbTestModeIdle;
+
     k_sem_reset(&radioXferDone);
 
     k_mutex_unlock(&radio_busy);
@@ -242,11 +272,154 @@ void esb_set_ack_enabled(bool enabled) {
     k_mutex_unlock(&radio_busy);
 }
 
-void esb_set_channel(uint8_t channel)
+bool esb_is_valid_nrf_tx_power(uint8_t raw_power)
+{
+#if defined(RADIO_TXPOWER_TXPOWER_Neg40dBm)
+    if (raw_power == (uint8_t)NRF_RADIO_TXPOWER_NEG40DBM) {
+        return true;
+    }
+#endif
+    if (raw_power == (uint8_t)NRF_RADIO_TXPOWER_NEG20DBM ||
+        raw_power == (uint8_t)NRF_RADIO_TXPOWER_NEG16DBM ||
+        raw_power == (uint8_t)NRF_RADIO_TXPOWER_NEG12DBM ||
+        raw_power == (uint8_t)NRF_RADIO_TXPOWER_NEG8DBM ||
+        raw_power == (uint8_t)NRF_RADIO_TXPOWER_NEG4DBM ||
+        raw_power == (uint8_t)NRF_RADIO_TXPOWER_0DBM) {
+        return true;
+    }
+#if defined(RADIO_TXPOWER_TXPOWER_Pos2dBm)
+    if (raw_power == (uint8_t)NRF_RADIO_TXPOWER_POS2DBM) {
+        return true;
+    }
+#endif
+#if defined(RADIO_TXPOWER_TXPOWER_Pos3dBm)
+    if (raw_power == (uint8_t)NRF_RADIO_TXPOWER_POS3DBM) {
+        return true;
+    }
+#endif
+#if defined(RADIO_TXPOWER_TXPOWER_Pos4dBm)
+    if (raw_power == (uint8_t)NRF_RADIO_TXPOWER_POS4DBM) {
+        return true;
+    }
+#endif
+#if defined(RADIO_TXPOWER_TXPOWER_Pos5dBm)
+    if (raw_power == (uint8_t)NRF_RADIO_TXPOWER_POS5DBM) {
+        return true;
+    }
+#endif
+#if defined(RADIO_TXPOWER_TXPOWER_Pos6dBm)
+    if (raw_power == (uint8_t)NRF_RADIO_TXPOWER_POS6DBM) {
+        return true;
+    }
+#endif
+#if defined(RADIO_TXPOWER_TXPOWER_Pos7dBm)
+    if (raw_power == (uint8_t)NRF_RADIO_TXPOWER_POS7DBM) {
+        return true;
+    }
+#endif
+#if defined(RADIO_TXPOWER_TXPOWER_Pos8dBm)
+    if (raw_power == (uint8_t)NRF_RADIO_TXPOWER_POS8DBM) {
+        return true;
+    }
+#endif
+
+    return false;
+}
+
+bool esb_test_mode_is_active(void)
+{
+    return test_mode != esbTestModeIdle;
+}
+
+void esb_get_test_state(struct esbTestState_s *test_state)
+{
+    if (test_state == NULL) {
+        return;
+    }
+
+    k_mutex_lock(&radio_busy, K_FOREVER);
+    test_state->mode = (uint8_t)test_mode;
+    test_state->channel = current_channel;
+    test_state->nrf_tx_power = current_nrf_tx_power;
+    test_pa_power = fem_get_power();
+    test_state->pa_power = test_pa_power;
+    k_mutex_unlock(&radio_busy);
+}
+
+bool esb_set_test_mode(esbTestMode_t mode)
+{
+    switch (mode) {
+        case esbTestModeIdle:
+        case esbTestModeUnmodulatedCarrier:
+        case esbTestModeModulatedCarrier1M:
+        case esbTestModeModulatedCarrier2M:
+            break;
+        default:
+            return false;
+    }
+
+    if (!isInit && mode != esbTestModeIdle) {
+        return false;
+    }
+
+    if (sniffer_active && mode != esbTestModeIdle) {
+        return false;
+    }
+
+    k_mutex_lock(&radio_busy, K_FOREVER);
+    if (test_mode != esbTestModeIdle) {
+        test_mode_stop_locked();
+    }
+    test_mode = mode;
+    if (mode != esbTestModeIdle && current_channel <= 100) {
+        test_mode_start_locked();
+    }
+    k_mutex_unlock(&radio_busy);
+    return true;
+}
+
+bool esb_set_test_nrf_tx_power(uint8_t raw_power)
+{
+    if (!esb_is_valid_nrf_tx_power(raw_power)) {
+        return false;
+    }
+
+    k_mutex_lock(&radio_busy, K_FOREVER);
+    current_nrf_tx_power = raw_power;
+    if (test_mode != esbTestModeIdle) {
+        test_mode_restart_locked();
+    } else {
+        nrf_radio_txpower_set(NRF_RADIO, (nrf_radio_txpower_t)raw_power);
+        current_nrf_tx_power = (uint8_t)nrf_radio_txpower_get(NRF_RADIO);
+    }
+    k_mutex_unlock(&radio_busy);
+    return true;
+}
+
+bool esb_set_test_pa_power(uint8_t power)
+{
+    if (power > 31) {
+        return false;
+    }
+    k_mutex_lock(&radio_busy, K_FOREVER);
+    fem_set_power(power);
+    test_pa_power = fem_get_power();
+    k_mutex_unlock(&radio_busy);
+    return true;
+}
+
+void esb_set_channel(uint16_t channel)
 {
     k_mutex_lock(&radio_busy, K_FOREVER);
     if (channel <= 100) {
-        nrf_radio_frequency_set(NRF_RADIO, 2400+channel);
+        current_channel = channel;
+        if (test_mode != esbTestModeIdle) {
+            test_mode_restart_locked();
+        } else {
+            nrf_radio_frequency_set(NRF_RADIO, 2400 + channel);
+        }
+    } else if (test_mode != esbTestModeIdle) {
+        test_mode_stop_locked();
     }
     k_mutex_unlock(&radio_busy);
 }
@@ -256,11 +429,14 @@ void esb_set_bitrate(esbBitrate_t bitrate)
     k_mutex_lock(&radio_busy, K_FOREVER);
     switch(bitrate) {
         case radioBitrate1M:
-            nrf_radio_mode_set(NRF_RADIO, RADIO_MODE_MODE_Nrf_1Mbit);
+            current_normal_radio_mode = NRF_RADIO_MODE_NRF_1MBIT;
             break;
         case radioBitrate2M:
-            nrf_radio_mode_set(NRF_RADIO, RADIO_MODE_MODE_Nrf_2Mbit);
+            current_normal_radio_mode = NRF_RADIO_MODE_NRF_2MBIT;
             break;
+    }
+    if (test_mode == esbTestModeIdle) {
+        nrf_radio_mode_set(NRF_RADIO, current_normal_radio_mode);
     }
     k_mutex_unlock(&radio_busy);
 }
@@ -314,7 +490,11 @@ bool esb_send_packet(struct esbPacket_s *packet, struct esbPacket_s * ack, uint8
         return false;
     }
 
-    if (continuous_carrier_enabled || sniffer_active) {
+    if (test_mode != esbTestModeIdle) {
+        return false;
+    }
+
+    if (sniffer_active) {
         return false;
     }
 
@@ -429,37 +609,138 @@ bool esb_send_packet(struct esbPacket_s *packet, struct esbPacket_s * ack, uint8
     }
 }
 
+static void radio_dtx_set(uint8_t default_tx)
+{
+#if defined(RADIO_MODECNF0_RU_Msk)
+    nrf_radio_modecnf0_set(NRF_RADIO, nrf_radio_modecnf0_ru_get(NRF_RADIO), default_tx);
+#elif defined(RADIO_MODECNF0_DTX_Msk)
+    NRF_RADIO->MODECNF0 = (NRF_RADIO->MODECNF0 & ~RADIO_MODECNF0_DTX_Msk) |
+                          (((uint32_t)default_tx) << RADIO_MODECNF0_DTX_Pos);
+#else
+    ARG_UNUSED(default_tx);
+#endif
+}
+
+static void restore_normal_radio_config_locked(void)
+{
+    nrf_radio_int_disable(NRF_RADIO, 0xffffffffUL);
+    nrf_radio_shorts_set(NRF_RADIO,
+        NRF_RADIO_SHORT_ADDRESS_RSSISTART_MASK |
+        NRF_RADIO_SHORT_DISABLED_RSSISTOP_MASK);
+
+    nrf_radio_packet_conf_t radioConfig = {0,};
+    radioConfig.lflen = 6;
+    radioConfig.s0len = 0;
+    radioConfig.s1len = 3;
+    radioConfig.maxlen = 32;
+    radioConfig.statlen = 0;
+    radioConfig.balen = 4;
+    radioConfig.big_endian = true;
+    radioConfig.whiteen = false;
+    nrf_radio_packet_configure(NRF_RADIO, &radioConfig);
+
+    nrf_radio_crc_configure(NRF_RADIO, 2, NRF_RADIO_CRC_ADDR_INCLUDE, 0x11021UL);
+    nrf_radio_crcinit_set(NRF_RADIO, 0xfffful);
+    nrf_radio_rxaddresses_set(NRF_RADIO, 0x01u);
+    nrf_radio_mode_set(NRF_RADIO, current_normal_radio_mode);
+#if defined(RADIO_MODECNF0_DTX_B1)
+    radio_dtx_set(RADIO_MODECNF0_DTX_B1);
+#endif
+}
+
+static void configure_test_modulated_packet_locked(void)
+{
+    test_tx_packet[0] = sizeof(test_tx_packet) - 1;
+    memset(&test_tx_packet[1], 0xf0, sizeof(test_tx_packet) - 1);
+
+    nrf_radio_packet_conf_t radioConfig = {0,};
+    radioConfig.lflen = 8;
+    radioConfig.s0len = 0;
+    radioConfig.s1len = 0;
+    radioConfig.maxlen = sizeof(test_tx_packet) - 1;
+    radioConfig.statlen = 0;
+    radioConfig.balen = 4;
+    radioConfig.big_endian = true;
+    radioConfig.whiteen = true;
+    nrf_radio_packet_configure(NRF_RADIO, &radioConfig);
+
+    nrf_radio_crc_configure(NRF_RADIO, 0, NRF_RADIO_CRC_ADDR_INCLUDE, 0);
+#if defined(RADIO_MODECNF0_DTX_B1)
+    radio_dtx_set(RADIO_MODECNF0_DTX_B1);
+#endif
+    nrf_radio_packetptr_set(NRF_RADIO, test_tx_packet);
+}
+
 bool esb_set_continuous_carrier(bool enable) {
-    if (!isInit) {
-        return false;
+    return esb_set_test_mode(enable ? esbTestModeUnmodulatedCarrier : esbTestModeIdle);
+}
+
+static void test_mode_stop_locked(void)
+{
+    nrf_radio_int_disable(NRF_RADIO, 0xffffffffUL);
+    nrf_radio_task_trigger(NRF_RADIO, NRF_RADIO_TASK_DISABLE);
+    k_sleep(K_USEC(200));
+    nrf_radio_event_clear(NRF_RADIO, NRF_RADIO_EVENT_DISABLED);
+    nrf_radio_event_clear(NRF_RADIO, NRF_RADIO_EVENT_END);
+    fem_txen_set(false);
+    restore_normal_radio_config_locked();
+}
+
+static void test_mode_start_locked(void)
+{
+    nrf_radio_int_disable(NRF_RADIO, 0xffffffffUL);
+    nrf_radio_task_trigger(NRF_RADIO, NRF_RADIO_TASK_DISABLE);
+    k_sleep(K_USEC(200));
+    nrf_radio_event_clear(NRF_RADIO, NRF_RADIO_EVENT_DISABLED);
+    nrf_radio_event_clear(NRF_RADIO, NRF_RADIO_EVENT_READY);
+    nrf_radio_event_clear(NRF_RADIO, NRF_RADIO_EVENT_END);
+
+    if (current_channel <= 100) {
+        nrf_radio_frequency_set(NRF_RADIO, 2400 + current_channel);
     }
+    nrf_radio_txpower_set(NRF_RADIO, (nrf_radio_txpower_t)current_nrf_tx_power);
+    fem_set_power(test_pa_power);
+    fem_rxen_set(false);
+    fem_txen_set(true);
 
-    if (sniffer_active) {
-        return false;
-    }
-
-    if (enable == continuous_carrier_enabled) {
-        return false;
-    }
-
-    k_mutex_lock(&radio_busy, K_FOREVER);
-    if (enable) {
-        fem_txen_set(true);
-
+    if (test_mode == esbTestModeUnmodulatedCarrier) {
+        nrf_radio_int_disable(NRF_RADIO, 0xffffffffUL);
+        nrf_radio_shorts_set(NRF_RADIO, 0);
+#if defined(RADIO_MODECNF0_DTX_Center)
+        radio_dtx_set(RADIO_MODECNF0_DTX_Center);
+#endif
         nrf_radio_task_trigger(NRF_RADIO, NRF_RADIO_TASK_TXEN);
-
-
-    } else {
-        nrf_radio_task_trigger(NRF_RADIO, NRF_RADIO_TASK_DISABLE);
-
-        fem_txen_set(false);
+        return;
     }
 
+    if (test_mode == esbTestModeModulatedCarrier1M) {
+        nrf_radio_mode_set(NRF_RADIO, NRF_RADIO_MODE_NRF_1MBIT);
+    } else if (test_mode == esbTestModeModulatedCarrier2M) {
+        nrf_radio_mode_set(NRF_RADIO, NRF_RADIO_MODE_NRF_2MBIT);
+    } else {
+        fem_txen_set(false);
+        return;
+    }
 
-    continuous_carrier_enabled = enable;
+    configure_test_modulated_packet_locked();
+    nrf_radio_shorts_set(NRF_RADIO, RADIO_SHORTS_READY_START_Msk);
+    nrf_radio_int_enable(NRF_RADIO, NRF_RADIO_INT_END_MASK);
+    nrf_radio_task_trigger(NRF_RADIO, NRF_RADIO_TASK_TXEN);
+}
 
-    k_mutex_unlock(&radio_busy);
-    return true;
+static void test_mode_restart_locked(void)
+{
+    if (test_mode == esbTestModeIdle) {
+        return;
+    }
+
+    esbTestMode_t mode = test_mode;
+
+    test_mode_stop_locked();
+    test_mode = mode;
+    if (current_channel <= 100) {
+        test_mode_start_locked();
+    }
 }
 
 void esb_set_address_pipe1(uint8_t address[5])
@@ -480,6 +761,11 @@ void esb_sniffer_start(esb_sniffer_rx_cb_t cb)
     }
 
     k_mutex_lock(&radio_busy, K_FOREVER);
+
+    if (test_mode != esbTestModeIdle) {
+        test_mode_stop_locked();
+        test_mode = esbTestModeIdle;
+    }
 
     sniffer_active = true;
     sniffer_callback = cb;

--- a/src/esb.h
+++ b/src/esb.h
@@ -27,6 +27,27 @@
 
 #define ESB_MAX_PAYLOAD_LENGTH 63
 
+typedef enum {
+    esbTestModeIdle = 0,
+    esbTestModeUnmodulatedCarrier = 1,
+    esbTestModeModulatedCarrier1M = 2,
+    esbTestModeModulatedCarrier2M = 3,
+} esbTestMode_t;
+
+struct esbTestState_s {
+    uint8_t mode;
+    uint8_t channel;
+    uint8_t nrf_tx_power;
+    uint8_t pa_power;
+} __attribute__((packed));
+
+bool esb_is_valid_nrf_tx_power(uint8_t raw_power);
+bool esb_test_mode_is_active(void);
+bool esb_set_test_mode(esbTestMode_t mode);
+bool esb_set_test_nrf_tx_power(uint8_t raw_power);
+bool esb_set_test_pa_power(uint8_t power);
+void esb_get_test_state(struct esbTestState_s *test_state);
+
 void esb_init();
 void esb_deinit();
 
@@ -37,7 +58,7 @@ void esb_deinit();
  * 
  * @param channel A channel from 0 to 100
  */
-void esb_set_channel(uint8_t channel);
+void esb_set_channel(uint16_t channel);
 
 /**
  * @brief Possible radio bitrate
@@ -110,7 +131,7 @@ bool esb_send_packet(struct esbPacket_s *packet, struct esbPacket_s * ack, uint8
  * purposes, such as measuring output power or spectrum analysis.
  * 
  * @param enable true to enable continuous carrier mode, false to disable it
- * @return true if the operation was successful, false if no change was made
+ * @return true if the operation was successful, false otherwise
  */
 bool esb_set_continuous_carrier(bool enable);
 

--- a/src/fem.c
+++ b/src/fem.c
@@ -53,6 +53,8 @@ LOG_MODULE_REGISTER(fem);
 
 #include "radio_nrf5_fem.h"
 
+static uint8_t current_power;
+
 static void write_register(uint8_t address, uint8_t value);
 static uint8_t read_register(uint8_t address);
 
@@ -190,6 +192,8 @@ void fem_init() {
 	if (data[1] != 0x02) {
 		// TODO: Handle FEM communication error!
 	}
+
+	current_power = (read_register(0x00) >> 2) & 0x1f;
 #endif
 }
 
@@ -206,12 +210,17 @@ void fem_rxen_set(bool enable) {
 }
 
 void fem_set_power(uint8_t power) {
-#if defined(HAL_RADIO_FEM_IS_NRF21540)
 	uint8_t tx_gain = power & 0x1f;
+#if defined(HAL_RADIO_FEM_IS_NRF21540)
 	uint8_t confreg0 = tx_gain << 2;
 
 	write_register(0x00, confreg0);
 #endif
+	current_power = tx_gain;
+}
+
+uint8_t fem_get_power(void) {
+	return current_power;
 }
 
 static void write_register(uint8_t address, uint8_t value) {

--- a/src/fem.h
+++ b/src/fem.h
@@ -34,6 +34,8 @@ void fem_rxen_set(bool enable);
 
 void fem_set_power(uint8_t power);
 
+uint8_t fem_get_power(void);
+
 void fem_set_antenna(uint8_t antenna);
 
 bool fem_is_lna_enabled(void);

--- a/src/legacy_usb.c
+++ b/src/legacy_usb.c
@@ -63,7 +63,7 @@ static void handle_vendor_command(struct setup_command* setup);
 // state
 static struct {
     uint8_t datarate;
-	uint8_t channel;
+	uint16_t channel;
     bool ack_enabled;
     uint8_t scan_result[ESB_MAX_PAYLOAD_LENGTH];
     int scan_result_length;
@@ -237,6 +237,10 @@ static struct usb_ep_cfg_data ep_cfg[] = {
 #define SET_SNIFFER_ADDRESS 0x25
 #define GET_SNIFFER_DROP_COUNT 0x26
 #define SET_PACKET_LOSS_SIMULATION 0x30
+#define SET_TEST_MODE          0x31
+#define SET_TEST_NRF_TX_POWER  0x32
+#define SET_TEST_PA_POWER      0x33
+#define GET_TEST_STATE         0x34
 #define RESET_TO_BOOTLOADER 0xff
 
 // Inline mode values
@@ -278,7 +282,15 @@ static int crazyradio_vendor_handler(struct usb_setup_packet *setup,
             (setup->bRequest == SET_INLINE_MODE && setup->wValue <= INLINE_MODE_ON_WITH_RSSI) ||
             setup->bRequest == SET_SNIFFER_ADDRESS ||
             (setup->bRequest == SET_RADIO_MODE && setup->wValue <= 1) ||
-            setup->bRequest == SET_PACKET_LOSS_SIMULATION) {
+            setup->bRequest == SET_PACKET_LOSS_SIMULATION ||
+            (setup->bRequest == SET_TEST_MODE && usb_reqtype_is_to_device(setup) &&
+             setup->wIndex == 0 && setup->wLength == 0 &&
+             setup->wValue <= esbTestModeModulatedCarrier2M) ||
+            (setup->bRequest == SET_TEST_NRF_TX_POWER && usb_reqtype_is_to_device(setup) &&
+             setup->wIndex == 0 && setup->wLength == 0 && setup->wValue <= 0xff &&
+             esb_is_valid_nrf_tx_power((uint8_t)setup->wValue)) ||
+            (setup->bRequest == SET_TEST_PA_POWER && usb_reqtype_is_to_device(setup) &&
+             setup->wIndex == 0 && setup->wLength == 0 && setup->wValue <= 31)) {
             
             LOG_DBG("Queuing command %d", setup->bRequest);
 
@@ -305,6 +317,14 @@ static int crazyradio_vendor_handler(struct usb_setup_packet *setup,
         } else if (setup->bRequest == CHANNEL_SCANN && usb_reqtype_is_to_host(setup)) {
             *data = state.scan_result;
             *len = MIN(state.scan_result_length, setup->wLength);
+        }
+        else if (setup->bRequest == GET_TEST_STATE && usb_reqtype_is_to_host(setup) &&
+                 setup->wValue == 0 && setup->wIndex == 0 &&
+                 setup->wLength == sizeof(struct esbTestState_s)) {
+            static struct esbTestState_s test_state;
+            esb_get_test_state(&test_state);
+            *data = (uint8_t *)&test_state;
+            *len = sizeof(test_state);
         }
         else if (setup->bRequest == GET_SNIFFER_DROP_COUNT && usb_reqtype_is_to_host(setup)) {
             static uint32_t drop_count_le;
@@ -422,6 +442,35 @@ static void usb_thread(void *, void *, void *) {
         k_msgq_get(&command_queue, &command, K_FOREVER);
 
         k_mutex_lock(&usb_radio_mutex, K_FOREVER);
+        if (command.type == command_data && esb_test_mode_is_active()) {
+            if (state.inline_mode && !state.inline_rssi_mode) {
+                inline_mode_in_header test_mode_header = {
+                    .length = sizeof(inline_mode_in_header),
+                    .ack_received = 0,
+                    .rssi_lt_64dbm = 0,
+                    .invalid_settings = 0,
+                    .arc_counter = 0,
+                };
+                usb_write(CRAZYRADIO_IN_EP_ADDR, (void *)&test_mode_header,
+                          test_mode_header.length, NULL);
+            } else if (state.inline_mode && state.inline_rssi_mode) {
+                inline_rssi_mode_in_header test_mode_header = {
+                    .length = sizeof(inline_rssi_mode_in_header),
+                    .ack_received = 0,
+                    .rssi_lt_64dbm = 0,
+                    .invalid_settings = 0,
+                    .arc_counter = 0,
+                    .rssi_dbm = 0,
+                };
+                usb_write(CRAZYRADIO_IN_EP_ADDR, (void *)&test_mode_header,
+                          test_mode_header.length, NULL);
+            } else if (state.ack_enabled) {
+                char no_ack_answer[1] = {0};
+                usb_write(CRAZYRADIO_IN_EP_ADDR, no_ack_answer, 1, NULL);
+            }
+            k_mutex_unlock(&usb_radio_mutex);
+            continue;
+        }
         if (command.type == command_data) {
             
             if (state.inline_mode) {
@@ -443,7 +492,7 @@ static void usb_thread(void *, void *, void *) {
                 packet.length = payload_length;
 
                 LOG_ERR("Inline mode packet: chan %d, dr %d, ack %d, addr %02x%02x%02x%02x%02x, len %d", state.channel, state.datarate, state.ack_enabled, header->address[0], header->address[1], header->address[2], header->address[3], header->address[4], payload_length);
-            } else if (!state.ack_enabled && command.data.length > 32) {
+            } else if (state.datarate != 0 && state.channel <= 100 && !state.ack_enabled && command.data.length > 32) {
                 // If we are not receiving ack (ie. broadcast) and the received data is > 32 bytes,
                 // this means that the buffer actually contains 2 packets to send
                 // Send the first one right away
@@ -621,9 +670,7 @@ static void handle_vendor_command(struct setup_command* setup) {
     if (setup->setup_packet.bRequest == SET_RADIO_CHANNEL && setup->setup_packet.wLength == 0) {
         LOG_DBG("Setting radio channel %d", setup->setup_packet.wValue);
         uint16_t channel = setup->setup_packet.wValue;
-        if (channel <= 100) {
-            esb_set_channel(channel);
-        }
+        esb_set_channel(channel);
         // If channel >100 used, packets will be ignored (ie. virtually not acked)
         state.channel = channel;
         // Reset inline mode
@@ -650,7 +697,7 @@ static void handle_vendor_command(struct setup_command* setup) {
         LOG_DBG("Setting radio power %d", setup->setup_packet.wValue);
         uint8_t power = MIN(setup->setup_packet.wValue, 3);
         uint8_t fem_power = power_mapping[power];
-        fem_set_power(fem_power);
+        esb_set_test_pa_power(fem_power);
     } else if (setup->setup_packet.bRequest == SET_RADIO_ARD && setup->setup_packet.wLength == 0) {
         LOG_DBG("Setting radio ARD %d", setup->setup_packet.wValue);
     } else if (setup->setup_packet.bRequest == SET_RADIO_ARC && setup->setup_packet.wLength == 0) {
@@ -698,6 +745,18 @@ static void handle_vendor_command(struct setup_command* setup) {
         LOG_DBG("Setting radio Inline Mode %d", setup->setup_packet.wValue);
         state.inline_mode = setup->setup_packet.wValue != 0;
         state.inline_rssi_mode = setup->setup_packet.wValue == INLINE_MODE_ON_WITH_RSSI;
+    } else if (setup->setup_packet.bRequest == SET_TEST_MODE &&
+               setup->setup_packet.wIndex == 0 && setup->setup_packet.wLength == 0) {
+        LOG_DBG("Setting test mode %d", setup->setup_packet.wValue);
+        esb_set_test_mode((esbTestMode_t)setup->setup_packet.wValue);
+    } else if (setup->setup_packet.bRequest == SET_TEST_NRF_TX_POWER &&
+               setup->setup_packet.wIndex == 0 && setup->setup_packet.wLength == 0) {
+        LOG_DBG("Setting test nRF TX power %d", setup->setup_packet.wValue);
+        esb_set_test_nrf_tx_power((uint8_t)setup->setup_packet.wValue);
+    } else if (setup->setup_packet.bRequest == SET_TEST_PA_POWER &&
+               setup->setup_packet.wIndex == 0 && setup->setup_packet.wLength == 0) {
+        LOG_DBG("Setting test PA power %d", setup->setup_packet.wValue);
+        esb_set_test_pa_power((uint8_t)setup->setup_packet.wValue);
     } else if (setup->setup_packet.bRequest == SET_PACKET_LOSS_SIMULATION && setup->setup_packet.wLength == 2) {
         uint8_t packet_loss_percent = setup->data[0];
         uint8_t ack_loss_percent = setup->data[1];


### PR DESCRIPTION
## Summary
- Add radio TEST mode state tracking and USB controls for carrier modes.
- Add radio TEST channel/power/readback handling and FEM PA gain readback.
- Document the compatible USB protocol extensions for radio TEST operation.

## Test plan
- git diff --check origin/main...HEAD
- west build -b crazyradio2