### PR TITLE
build: pin cmake<4.4 to fix Zephyr 4.2.0 build

### DIFF
--- a/justfile
+++ b/justfile
@@ -36,7 +36,7 @@ fetch-zephyr: west-exists
 # Fetch python dependencies
 fetch-python-dep:
     uv pip install -r zephyr/scripts/requirements.txt
-    uv pip install cmake ninja
+    uv pip install 'cmake<4.4' ninja
 
 # Prepare system to build the project. Alias for [fetch-zephyr fetch-zephyr-sdk fetch-python-dep]
 prepare-system:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,9 @@ dependencies = [
     "rust-just",
     "fzf-bin",
     "west",
-    "cmake",
+    # CMake 4.4 rejects the unquoted empty-variable if() in Zephyr 4.2.0's
+    # FindZephyr-sdk.cmake. 4.3 and older are fine.
+    "cmake<4.4",
     "ninja",
     "pyelftools>=0.32",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -52,7 +52,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cmake" },
+    { name = "cmake", specifier = "<4.4" },
     { name = "fzf-bin" },
     { name = "ninja" },
     { name = "pyelftools", specifier = ">=0.32" },


### PR DESCRIPTION
CMake 4.4 made an unquoted empty-variable expansion in if() a hard error. Zephyr 4.2.0's FindZephyr-sdk.cmake:57 has one:

    if(("zephyr" STREQUAL ${ZEPHYR_TOOLCHAIN_VARIANT}) OR ...

which fails with "Unknown arguments specified" when ZEPHYR_TOOLCHAIN_VARIANT is unset, breaking the weekly CI build once runners picked up cmake 4.4.0.

Pin in both pyproject.toml and the justfile: CI runs `uv pip install .` first, but `just fetch-python-dep` reinstalls cmake afterwards and would otherwise pull the latest version back in.

Verified by full firmware build with cmake 4.3.0 and 4.3.4; 4.4.0 fails at configure.